### PR TITLE
修复在**桌面浏览器**中主标题编辑后无法立即更新的问题

### DIFF
--- a/app/components/GameGrid.tsx
+++ b/app/components/GameGrid.tsx
@@ -121,7 +121,7 @@ export function GameGrid({ initialCells, onUpdateCells }: GameGridProps) {
     if (drawCanvas) {
       drawCanvas();
     }
-  }, [currentDragOverCellId, drawCanvas]);
+  }, [currentDragOverCellId, globalConfig, drawCanvas]);
 
   // 保存标题更改
   const handleSaveTitle = (newText: string) => {
@@ -172,12 +172,12 @@ export function GameGrid({ initialCells, onUpdateCells }: GameGridProps) {
     const storageKey = `gameGridGlobalConfig_${locale}`
     localStorage.setItem(storageKey, JSON.stringify(updatedConfig));
     
-    // 强制重绘画布
-    setTimeout(() => {
-      if (drawCanvas) {
-        drawCanvas();
-      }
-    }, 0);
+    // // 强制重绘画布
+    // setTimeout(() => {
+    //   if (drawCanvas) {
+    //     drawCanvas();
+    //   }
+    // }, 0);
     
     // 更新页面标题
     if (typeof document !== 'undefined') {


### PR DESCRIPTION
在 useEffect 依赖中添加 globalConfig，确保状态更新时自动触发画布重绘。
修复了桌面端编辑主标题后需要刷新才能看到更新的问题（移动端倒是没有这个问题）