### PR TITLE
提高导出图片分辨率

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -7,24 +7,25 @@ export const isBrowser = typeof window !== 'undefined';
 
 /**
  * Canvas配置
+ * 使用2倍分辨率以提高导出图片的清晰度
  */
 export const CANVAS_CONFIG: CanvasConfig = {
-  width: 1200,
-  height: 1300,
-  padding: 40,
-  titleHeight: 50,
+  width: 2400,  
+  height: 2600, 
+  padding: 80,  
+  titleHeight: 100, 
   gridRows: 4,
   gridCols: 6,
-  cellPadding: 10,
-  cellBorderWidth: 2,
-  cellBorderRadius: 8,
+  cellPadding: 20, 
+  cellBorderWidth: 4, 
+  cellBorderRadius: 16, 
   cellAspectRatio: 0.75, // 宽高比为3:4
   coverRatio: 0.75, // 封面宽高比为3:4
-  titleFontSize: 48,
-  cellTitleFontSize: 22,
-  cellNameFontSize: 14,
-  cellTitleMargin: 6,
-  cellNameMargin: 6,
+  titleFontSize: 96, 
+  cellTitleFontSize: 44, 
+  cellNameFontSize: 28, 
+  cellTitleMargin: 12, 
+  cellNameMargin: 12, 
 };
 
 /**
@@ -67,23 +68,31 @@ export const CELL_TITLES = [
 ];
 
 // 添加 Canvas.roundRect polyfill，以兼容旧版浏览器
+interface BorderRadius {
+  tl: number;
+  tr: number;
+  br: number;
+  bl: number;
+}
+
 if (isBrowser && !CanvasRenderingContext2D.prototype.roundRect) {
-  CanvasRenderingContext2D.prototype.roundRect = function (x, y, width, height, radius) {
+  CanvasRenderingContext2D.prototype.roundRect = function (x: number, y: number, width: number, height: number, radius: number | BorderRadius | any) {
+    let r: BorderRadius;
     if (typeof radius === 'number') {
-      radius = { tl: radius, tr: radius, br: radius, bl: radius };
+      r = { tl: radius, tr: radius, br: radius, bl: radius };
     } else {
-      radius = { ...{ tl: 0, tr: 0, br: 0, bl: 0 }, ...radius };
+      r = { tl: 0, tr: 0, br: 0, bl: 0, ...radius };
     }
     this.beginPath();
-    this.moveTo(x + radius.tl, y);
-    this.lineTo(x + width - radius.tr, y);
-    this.quadraticCurveTo(x + width, y, x + width, y + radius.tr);
-    this.lineTo(x + width, y + height - radius.br);
-    this.quadraticCurveTo(x + width, y + height, x + width - radius.br, y + height);
-    this.lineTo(x + radius.bl, y + height);
-    this.quadraticCurveTo(x, y + height, x, y + height - radius.bl);
-    this.lineTo(x, y + radius.tl);
-    this.quadraticCurveTo(x, y, x + radius.tl, y);
+    this.moveTo(x + r.tl, y);
+    this.lineTo(x + width - r.tr, y);
+    this.quadraticCurveTo(x + width, y, x + width, y + r.tr);
+    this.lineTo(x + width, y + height - r.br);
+    this.quadraticCurveTo(x + width, y + height, x + width - r.br, y + height);
+    this.lineTo(x + r.bl, y + height);
+    this.quadraticCurveTo(x, y + height, x, y + height - r.bl);
+    this.lineTo(x, y + r.tl);
+    this.quadraticCurveTo(x, y, x + r.tl, y);
     this.closePath();
     return this;
   };

--- a/app/hooks/useCanvasRenderer.tsx
+++ b/app/hooks/useCanvasRenderer.tsx
@@ -195,7 +195,7 @@ export function useCanvasRenderer({
 
       // 添加水印
       ctx.fillStyle = "#9ca3af" // 使用灰色
-      ctx.font = "14px sans-serif"
+      ctx.font = "28px sans-serif" 
       ctx.textAlign = "right"
       ctx.fillText(
         "gamegrid.shatranj.space",
@@ -308,7 +308,7 @@ export function useCanvasRenderer({
     // 绘制游戏手柄图标
     ctx.fillStyle = "#9ca3af";
     ctx.strokeStyle = "#9ca3af";
-    ctx.lineWidth = 3;
+    ctx.lineWidth = 6; 
     gamepadIconPath(iconX, iconY, iconSize).forEach((cmd) => {
       if (cmd.cmd === "beginPath") {
         ctx.beginPath();


### PR DESCRIPTION
## 主要改动
- 将Canvas尺寸提升2倍（1200X1300 -> 2400x2600）
- 所有相关参数（文字、边框等）同步调整
- 从PNG格式切换为JPEG，并实现智能质量调整，确保导出文件始终≤5MB（实际上一般导出只有2MB左右，和修改前差不多）

## 截图



| 当前                                                         | 修改后                                                       |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| <img width="730" height="1153" alt="before" src="https://github.com/user-attachments/assets/52e1c26d-b606-4765-9119-299be22a5bb4" /> | <img width="729" height="1149" alt="after" src="https://github.com/user-attachments/assets/c60e03b0-227b-45d8-b686-3a99c907e633" /> |